### PR TITLE
Fix skipButton returning undefined

### DIFF
--- a/skipad.js
+++ b/skipad.js
@@ -12,7 +12,7 @@
     if (window.location.pathname !== '/watch') {
       return;
     }
-    var skipButton = document.querySelector('button.videoAdUiSkipButton');
+    var skipButton = document.getElementsByClassName('videoAdUiSkipButton')[0];
     if (skipButton) {
       eventFire(skipButton, 'click');
     }


### PR DESCRIPTION
The extension stopped working on youtube for me so I tried:

document.querySelector('button.videoAdUiSkipButton')

in the console and it turned undefined.

Not sure why it wouldn't work anymore but easy fix.