### PR TITLE
Only click skip ad button after it is visible

### DIFF
--- a/skipad.js
+++ b/skipad.js
@@ -17,9 +17,13 @@
    * @returns {Array<Element>} - An arry of DOM elements
    */
   function existingButtons(classNames) {
-    return classNames.map(name => {
-      return document.getElementsByClassName(name)[0];
-    }).filter(v => v);
+    return classNames
+      .map(name => {
+        return Array.from(document.getElementsByClassName(name)) || [];
+      })
+      .reduce(function(acc, elems) {
+        return acc.concat(elems);
+      }, [])
   }
 
   /**

--- a/skipad.js
+++ b/skipad.js
@@ -130,9 +130,9 @@
   function triggerClick(el) {
     var etype = 'click';
 
-    if (el.fireEvent) {
+    if (typeof el.fireEvent === 'function') {
       el.fireEvent('on' + etype);
-    } else {
+    } else if (typeof el.dispatchEvent === 'function') {
       var evObj = document.createEvent('Events');
       evObj.initEvent(etype, true, false);
       el.dispatchEvent(evObj);


### PR DESCRIPTION
- YouTube now has the skip ad button available in the DOM from the beginning of the video. It is just hidden. Because of this the extension was skipping ads even before the skip ad button was visible. I think the expectation of users using this extension is that the extension is just automating the action that the user could do themselves so it is important to wait until the button is actually present on the screen.

- This also keeps the possibility of implementing a continue playing button to not skip ads for that particular video.