### PR TITLE
Added support for the music.youtube.com player

### DIFF
--- a/src/contentScripts/youtube.ts
+++ b/src/contentScripts/youtube.ts
@@ -39,7 +39,7 @@ function handlePlayerMutation() {
 }
 
 /**
- * Initializes an observer on the YouTube Video Player to get events when any
+ * Initializes an observer on the YouTube Video Player or the Youtube Music Player to get events when any
  * of its child elements change. We can check for the existence of the skip ad
  * buttons on those changes.
  */
@@ -52,6 +52,9 @@ function initSkipAdBtnObserver() {
 
   const ytdPlayer = document.querySelector<HTMLElement>(
     "ytd-player#ytd-player"
+  ) ||
+  document.querySelector<HTMLElement>(
+    "ytmusic-player#player"
   );
 
   if (!ytdPlayer) {


### PR DESCRIPTION
The player on music.youtube.com uses a different tag and different class name, but uses the same ad / skip ad button as youtube.com.

By searching for the music player if no video player were found, the extensions now skips ads on music.youtube.

Tested on google chrome

closes #41 