### PR TITLE
Added class name for "Modern" Skip button

### DIFF
--- a/src/utils/youtubeDOM.ts
+++ b/src/utils/youtubeDOM.ts
@@ -13,6 +13,7 @@ export function clickSkipAdBtn(): void {
   const elems = getElementsByClassNames([
     "videoAdUiSkipButton", // Old close ad button
     "ytp-ad-skip-button ytp-button", // New close ad button
+    "ytp-ad-skip-button-modern ytp-button", // Modern close ad button
   ]);
   logger.debug("clicking on elems: ", elems);
   elems.forEach((el) => clickElem(el));


### PR DESCRIPTION
Youtube recently introduced a new style of Skip button, the class name being appended with "modern". Adding this class name to add compatibility/restore functionality.