### PR TITLE
Support even newer skip button

### DIFF
--- a/src/utils/youtubeDOM.ts
+++ b/src/utils/youtubeDOM.ts
@@ -14,6 +14,7 @@ export function clickSkipAdBtn(): void {
     "videoAdUiSkipButton", // Old close ad button
     "ytp-ad-skip-button ytp-button", // New close ad button
     "ytp-ad-skip-button-modern ytp-button", // Modern close ad button
+    "button.ytp-skip-ad-button",
   ]);
   logger.debug("clicking on elems: ", elems);
   elems.forEach((el) => clickElem(el));

--- a/src/utils/youtubeDOM.ts
+++ b/src/utils/youtubeDOM.ts
@@ -14,7 +14,7 @@ export function clickSkipAdBtn(): void {
     "videoAdUiSkipButton", // Old close ad button
     "ytp-ad-skip-button ytp-button", // New close ad button
     "ytp-ad-skip-button-modern ytp-button", // Modern close ad button
-    "button.ytp-skip-ad-button",
+    "ytp-skip-ad-button",
   ]);
   logger.debug("clicking on elems: ", elems);
   elems.forEach((el) => clickElem(el));

--- a/src/utils/youtubeEvents.ts
+++ b/src/utils/youtubeEvents.ts
@@ -28,7 +28,11 @@ mainLoop(async () => {
   const adPlaying =
     document
       .querySelector(".ytp-ad-visit-advertiser-button")
-      ?.getAttribute("aria-label") ?? undefined;
+      ?.getAttribute("aria-label") ??
+    document
+      .querySelector(".ytp-ad-module [aria-label]")
+      ?.getAttribute("aria-label") ??
+    undefined;
   const eventsToCall: Events[] = [];
   const cbArg = [
     { ad: currentAd, location: currentLoc },


### PR DESCRIPTION
We're not stopping with the variants! Looks like YouTube shuffled some selectors around. Unfortunately, the ID isn't stable, so can't use that but from what I have seen and played around with `button.ytp-skip-ad-button` appears to be unique.

![grafik](https://github.com/squgeim/yt-ad-autoskipper/assets/26303198/25e6ebc4-094e-440d-b044-05df04733c5b)

Should close #63 and potentially #67 
